### PR TITLE
Use the humble branch for ros_gz

### DIFF
--- a/template_workspace.yaml
+++ b/template_workspace.yaml
@@ -8,7 +8,7 @@ repositories:
   ros_gz:
     type: git
     url: https://github.com/gazebosim/ros_gz.git
-    version: ros2
+    version: humble
   sdformat_urdf:
     type: git
     url: https://github.com/ros/sdformat_urdf.git


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #5 

## Summary
The `ros2` branch is now tracking Iron, so updating the workspace to use `humble`.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
