### PR TITLE
Readme and CMakeLists.txt documentation for the ros_gz_example_gazebo subfolder

### DIFF
--- a/ros_gz_example_gazebo/CMakeLists.txt
+++ b/ros_gz_example_gazebo/CMakeLists.txt
@@ -1,7 +1,12 @@
 cmake_minimum_required(VERSION 3.5)
 
+# Following directive defines the project name.
 project(ros_gz_example_gazebo)
 
+
+# Following directives find required packages and load their configuration.
+# The 'set' directive defines a variable (e.g. 'GZ_PLUGIN_VER').
+# Such variables can be used lateron in the CMakeLists.txt file.
 find_package(ament_cmake REQUIRED)
 
 find_package(gz-cmake3 REQUIRED)
@@ -12,18 +17,34 @@ set(GZ_COMMON_VER ${gz-common5_VERSION_MAJOR})
 find_package(gz-sim7 REQUIRED)
 set(GZ_SIM_VER ${gz-sim7_VERSION_MAJOR})
 
+
+# Following 'add_library' directive defines a library target named 'BasicSystem'.
+# The 'SHARED' keyword indicates that a shared library should be compiled, and
+# is followed by the list of source files for the target.
 add_library(BasicSystem
   SHARED
   src/BasicSystem.cc
 )
 
+# Following 'target_include_directories' directive specifies 'include' as the
+# include directory to use when compiling the 'BasicSystem' target.
+# The 'PRIVATE' keyword specifies that this directive will populate the
+# INCLUDE_DIRECTORIES property for the 'BasicSystem' target.
 target_include_directories(
   BasicSystem PRIVATE include
 )
 
+# Following 'target_link_libraries' directive specifies to use the 
+# gz-sim library when linking the 'BasicSystem' target.
+# The 'PRIVATE' keyword stipulates that the gz-sim library will not
+# automatically be included if the 'BasicSystem' target were to
+# be linked to anoter target. 
+# ${GZ_SIM_VER} is substituted by the value that is was set to above.
 target_link_libraries(BasicSystem PRIVATE
   gz-sim${GZ_SIM_VER}::gz-sim${GZ_SIM_VER})
 
+
+# Following directives similarly specify another target: 'FullSystem'.
 add_library(FullSystem
   SHARED
   src/FullSystem.cc
@@ -36,22 +57,41 @@ target_include_directories(
 target_link_libraries(FullSystem PRIVATE
   gz-sim${GZ_SIM_VER}::gz-sim${GZ_SIM_VER})
 
+
+
+# Following 'install' directive ensures that the compiled libraries
+# of the 'BasicSystem' and 'FullSystem' targets will be copied
+# to the subfolder 'lib/ros_gz_example_gazebo' of the install directory.
 install(
   TARGETS BasicSystem FullSystem
   DESTINATION lib/${PROJECT_NAME}
 )
 
+
+# Following 'install' directive ensures that the 'worlds' subfolder
+# will be copied to the 'share/ros_gz_example_gazebo/worlds'
+# subfolder of the installation directory.
 install(
   DIRECTORY worlds/
   DESTINATION share/${PROJECT_NAME}/worlds
 )
 
+
+# Following directives are used when testing.
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 endif()
 
+
+# Following hooks are used to ensure that the correct environment variables
+# will be set by exectuting 'sourece install/setup.bash' after compilation.
+# When using this template for your project, change the filenames of the
+# files in the 'hooks' folder, to correspond to your project name.
 ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/hooks/${PROJECT_NAME}.dsv.in")
 ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/hooks/${PROJECT_NAME}.sh.in")
 
+
+# Following directive configures ament based on the previous directives, and should
+# typically be the last directive in the CMakeLists.txt file.
 ament_package()

--- a/ros_gz_example_gazebo/README.md
+++ b/ros_gz_example_gazebo/README.md
@@ -1,10 +1,10 @@
 # ros_gz_example_gazebo
 
-This subfolder holds example source files and a `CMakeLists.txt` file, as a starting point for Gazebo implementations outside of the official Gazebo repositories.
+This subfolder holds example source files and a corresponding `CMakeLists.txt` file, as a starting point for compiling Gazebo implementations in a personal repository (i.e. not part of the official Gazebo source repositories).
 
 The provided `CMakeLists.txt` file contains the directives to compile two example Gazebo systems: `BasicSystem` and `FullSystem`.
 
-For more information on Gazebo sim systems, see following [Gazebo Sim tutorials](https://gazebosim.org/api/sim/7/tutorials.html):
+For more information on Gazebo Sim systems, see following [Gazebo Sim tutorials](https://gazebosim.org/api/sim/7/tutorials.html):
 
 - [Create System Plugins](https://gazebosim.org/api/sim/7/createsystemplugins.html)
 - [Migration from Gazebo Classic: Plugins](https://gazebosim.org/api/sim/7/migrationplugins.html)
@@ -32,8 +32,8 @@ class FullSystem:
     public gz::sim::ISystemReset
 ```
 
-See the comments in the sourece files for further documentation.
+See the comments in the source files for further documentation.
 
 ## `CMakeLists.txt`
 
-See the comments in the `CMakeLists.txt` file for further documentation.
+The provided `CMakeLists.txt` file contains comments that clarify the different sections and commands, and how to apply these to your project.

--- a/ros_gz_example_gazebo/README.md
+++ b/ros_gz_example_gazebo/README.md
@@ -1,0 +1,39 @@
+# ros_gz_example_gazebo
+
+This subfolder holds example source files and a `CMakeLists.txt` file, as a starting point for Gazebo implementations outside of the official Gazebo repositories.
+
+The provided `CMakeLists.txt` file contains the directives to compile two example Gazebo systems: `BasicSystem` and `FullSystem`.
+
+For more information on Gazebo sim systems, see following [Gazebo Sim tutorials](https://gazebosim.org/api/sim/7/tutorials.html):
+
+- [Create System Plugins](https://gazebosim.org/api/sim/7/createsystemplugins.html)
+- [Migration from Gazebo Classic: Plugins](https://gazebosim.org/api/sim/7/migrationplugins.html)
+
+
+## `BasicSystem` and `FullSystem`
+
+`BasicSystem` is an example system that implements only the `ISystemPostUpdate` interface:
+
+```c++
+ class BasicSystem:
+    public gz::sim::System,
+    public gz::sim::ISystemPostUpdate
+```
+
+`FullSystem` is an example system that implements all of the system interfaces:
+
+```c++
+class FullSystem:
+    public gz::sim::System,
+    public gz::sim::ISystemConfigure,
+    public gz::sim::ISystemPreUpdate,
+    public gz::sim::ISystemUpdate,
+    public gz::sim::ISystemPostUpdate,
+    public gz::sim::ISystemReset
+```
+
+See the comments in the sourece files for further documentation.
+
+## `CMakeLists.txt`
+
+See the comments in the `CMakeLists.txt` file for further documentation.


### PR DESCRIPTION
This PR adds a `README.md` and extra documentation in the `CMakeLists.txt` file, which I think is relevant to those having little CMake knowledge.