### PR TITLE
Making Fortress compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Or start by creating a workspace and cloning the template repository:
     sudo rosdep init
     rosdep update
     rosdep install --from-paths src --ignore-src -r -i -y --rosdistro <ROS_DISTRO>
-    sudo apt install ros-<ROS_DISTRO>-ros-gz && ros-<ROS_DISTRO>-sdformat-urdf
+    sudo apt install ros-<ROS_DISTRO>-ros-gz ros-<ROS_DISTRO>-sdformat-urdf
     ```
 
 1. Build the project

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A template project integrating ROS 2 and Gazebo simulator.
    Note: If you're using a specific and unsupported Gazebo version with ROS 2, you might need to set the `GZ_VERSION` environment variable, for example:
 
     ```bash
-    export GZ_VERSION=garden
+    export GZ_VERSION=fortress
     ```
 
 1. Install necessary tools
@@ -50,6 +50,7 @@ Or start by creating a workspace and cloning the template repository:
     sudo rosdep init
     rosdep update
     rosdep install --from-paths src --ignore-src -r -i -y --rosdistro <ROS_DISTRO>
+    sudo apt install ros-<ROS_DISTRO>-ros-gz && ros-<ROS_DISTRO>-sdformat-urdf
     ```
 
 1. Build the project

--- a/README.md
+++ b/README.md
@@ -13,9 +13,12 @@ A template project integrating ROS 2 and Gazebo simulator.
 
 
 ## Install
+
+For using the template with Gazebo Fortress switch to the `fortress` branch of this repository, otherwise use the default branch `main` for Gazebo Harmonic onwards.
+
 ### Requirements
 
-1. Choose a ROS and Gazebo combination  https://gazebosim.org/docs/harmonic/ros_installation
+1. Choose a ROS and Gazebo combination https://gazebosim.org/docs/latest/ros_installation
    Note: If you're using a specific and unsupported Gazebo version with ROS 2, you might need to set the `GZ_VERSION` environment variable, for example:
 
     ```bash
@@ -50,7 +53,6 @@ Or start by creating a workspace and cloning the template repository:
     sudo rosdep init
     rosdep update
     rosdep install --from-paths src --ignore-src -r -i -y --rosdistro <ROS_DISTRO>
-    sudo apt install ros-<ROS_DISTRO>-ros-gz ros-<ROS_DISTRO>-sdformat-urdf
     ```
 
 1. Build the project

--- a/ros_gz_example_bringup/CMakeLists.txt
+++ b/ros_gz_example_bringup/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.5)
 project(ros_gz_example_bringup)
 
 find_package(ament_cmake REQUIRED)
+find_package(ros_gz_example_description REQUIRED)
+find_package(ros_gz_example_gazebo REQUIRED)
 
 # Install project launch files
 install(

--- a/ros_gz_example_bringup/package.xml
+++ b/ros_gz_example_bringup/package.xml
@@ -9,6 +9,13 @@
   <author>Michael Carroll</author>
   <author>Dharini Dutia</author>
 
+  <depend>ros_gz</depend>
+  <depend>sdformat_urdf</depend>
+  <depend>joint_state_publisher_gui</depend>
+
+  <depend>ros_gz_example_description</depend>
+  <depend>ros_gz_example_gazebo</depend>
+
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/ros_gz_example_description/hooks/ros_gz_example_description.dsv.in
+++ b/ros_gz_example_description/hooks/ros_gz_example_description.dsv.in
@@ -1,1 +1,1 @@
-prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;share;@CMAKE_INSTALL_PREFIX@/share
+prepend-non-duplicate;IGN_GAZEBO_RESOURCE_PATH;share;@CMAKE_INSTALL_PREFIX@/share

--- a/ros_gz_example_description/hooks/ros_gz_example_description.sh.in
+++ b/ros_gz_example_description/hooks/ros_gz_example_description.sh.in
@@ -1,2 +1,2 @@
-ament_prepend_unique_value GZ_SIM_RESOURCE_PATH "$AMENT_CURRENT_PREFIX/share/@PROJECT_NAME@/models"
+ament_prepend_unique_value IGN_GAZEBO_RESOURCE_PATH "$AMENT_CURRENT_PREFIX/share/@PROJECT_NAME@/models"
 

--- a/ros_gz_example_gazebo/CMakeLists.txt
+++ b/ros_gz_example_gazebo/CMakeLists.txt
@@ -8,6 +8,7 @@ project(ros_gz_example_gazebo)
 # The 'set' directive defines a variable (e.g. 'GZ_PLUGIN_VER').
 # Such variables can be used lateron in the CMakeLists.txt file.
 find_package(ament_cmake REQUIRED)
+find_package(ros_gz_example_description REQUIRED)
 
 find_package(ignition-cmake2 REQUIRED)
 find_package(ignition-plugin1 REQUIRED COMPONENTS register)

--- a/ros_gz_example_gazebo/CMakeLists.txt
+++ b/ros_gz_example_gazebo/CMakeLists.txt
@@ -9,14 +9,13 @@ project(ros_gz_example_gazebo)
 # Such variables can be used lateron in the CMakeLists.txt file.
 find_package(ament_cmake REQUIRED)
 
-find_package(gz-cmake3 REQUIRED)
-find_package(gz-plugin2 REQUIRED COMPONENTS register)
-set(GZ_PLUGIN_VER ${gz-plugin2_VERSION_MAJOR})
-find_package(gz-common5 REQUIRED COMPONENTS profiler)
-set(GZ_COMMON_VER ${gz-common5_VERSION_MAJOR})
-find_package(gz-sim7 REQUIRED)
-set(GZ_SIM_VER ${gz-sim7_VERSION_MAJOR})
-
+find_package(gz-cmake2 REQUIRED)
+find_package(gz-plugin1 REQUIRED COMPONENTS register)
+set(GZ_PLUGIN_VER ${gz-plugin1_VERSION_MAJOR})
+find_package(gz-common4 REQUIRED COMPONENTS profiler)
+set(GZ_COMMON_VER ${gz-common4_VERSION_MAJOR})
+find_package(gz-sim6 REQUIRED)
+set(GZ_SIM_VER ${gz-sim6_VERSION_MAJOR})
 
 # Following 'add_library' directive defines a library target named 'BasicSystem'.
 # The 'SHARED' keyword indicates that a shared library should be compiled, and

--- a/ros_gz_example_gazebo/CMakeLists.txt
+++ b/ros_gz_example_gazebo/CMakeLists.txt
@@ -9,13 +9,13 @@ project(ros_gz_example_gazebo)
 # Such variables can be used lateron in the CMakeLists.txt file.
 find_package(ament_cmake REQUIRED)
 
-find_package(gz-cmake2 REQUIRED)
-find_package(gz-plugin1 REQUIRED COMPONENTS register)
-set(GZ_PLUGIN_VER ${gz-plugin1_VERSION_MAJOR})
-find_package(gz-common4 REQUIRED COMPONENTS profiler)
-set(GZ_COMMON_VER ${gz-common4_VERSION_MAJOR})
-find_package(gz-sim6 REQUIRED)
-set(GZ_SIM_VER ${gz-sim6_VERSION_MAJOR})
+find_package(ignition-cmake2 REQUIRED)
+find_package(ignition-plugin1 REQUIRED COMPONENTS register)
+set(GZ_PLUGIN_VER ${ignition-plugin1_VERSION_MAJOR})
+find_package(ignition-common4 REQUIRED COMPONENTS profiler)
+set(GZ_COMMON_VER ${ignition-common4_VERSION_MAJOR})
+find_package(ignition-gazebo6 REQUIRED)
+set(GZ_SIM_VER ${ignition-gazebo6_VERSION_MAJOR})
 
 # Following 'add_library' directive defines a library target named 'BasicSystem'.
 # The 'SHARED' keyword indicates that a shared library should be compiled, and
@@ -40,7 +40,7 @@ target_include_directories(
 # be linked to anoter target. 
 # ${GZ_SIM_VER} is substituted by the value that is was set to above.
 target_link_libraries(BasicSystem PRIVATE
-  gz-sim${GZ_SIM_VER}::gz-sim${GZ_SIM_VER})
+  ignition-gazebo${GZ_SIM_VER}::ignition-gazebo${GZ_SIM_VER})
 
 
 # Following directives similarly specify another target: 'FullSystem'.
@@ -54,7 +54,7 @@ target_include_directories(
 )
 
 target_link_libraries(FullSystem PRIVATE
-  gz-sim${GZ_SIM_VER}::gz-sim${GZ_SIM_VER})
+  ignition-gazebo${GZ_SIM_VER}::ignition-gazebo${GZ_SIM_VER})
 
 
 

--- a/ros_gz_example_gazebo/README.md
+++ b/ros_gz_example_gazebo/README.md
@@ -28,7 +28,7 @@ class FullSystem:
     public gz::sim::ISystemConfigure,
     public gz::sim::ISystemPreUpdate,
     public gz::sim::ISystemUpdate,
-    public gz::sim::ISystemPostUpdate,
+    public gz::sim::ISystemPostUpdate
 ```
 
 See the comments in the source files for further documentation.

--- a/ros_gz_example_gazebo/README.md
+++ b/ros_gz_example_gazebo/README.md
@@ -29,7 +29,6 @@ class FullSystem:
     public gz::sim::ISystemPreUpdate,
     public gz::sim::ISystemUpdate,
     public gz::sim::ISystemPostUpdate,
-    public gz::sim::ISystemReset
 ```
 
 See the comments in the source files for further documentation.

--- a/ros_gz_example_gazebo/hooks/ros_gz_example_gazebo.dsv.in
+++ b/ros_gz_example_gazebo/hooks/ros_gz_example_gazebo.dsv.in
@@ -1,2 +1,2 @@
-prepend-non-duplicate;GZ_SIM_RESOURCE_PATH;share/@PROJECT_NAME@/worlds
-prepend-non-duplicate;GZ_SIM_SYSTEM_PLUGIN_PATH;lib/@PROJECT_NAME@/
+prepend-non-duplicate;IGN_GAZEBO_RESOURCE_PATH;share/@PROJECT_NAME@/worlds
+prepend-non-duplicate;IGN_GAZEBO_SYSTEM_PLUGIN_PATH;lib/@PROJECT_NAME@/

--- a/ros_gz_example_gazebo/hooks/ros_gz_example_gazebo.sh.in
+++ b/ros_gz_example_gazebo/hooks/ros_gz_example_gazebo.sh.in
@@ -1,2 +1,2 @@
-ament_prepend_unique_value GZ_SIM_RESOURCE_PATH "$AMENT_CURRENT_PREFIX/share/@PROJECT_NAME@/worlds"
-ament_prepend_unique_value GZ_SIM_PLUGIn_PATH "$AMENT_CURRENT_PREFIX/lib/@PROJECT_NAME@"
+ament_prepend_unique_value IGN_GAZEBO_RESOURCE_PATH "$AMENT_CURRENT_PREFIX/share/@PROJECT_NAME@/worlds"
+ament_prepend_unique_value IGN_GAZEBO_PLUGIN_PATH "$AMENT_CURRENT_PREFIX/lib/@PROJECT_NAME@"

--- a/ros_gz_example_gazebo/include/ros_gz_example_gazebo/FullSystem.hh
+++ b/ros_gz_example_gazebo/include/ros_gz_example_gazebo/FullSystem.hh
@@ -35,7 +35,7 @@ namespace ros_gz_example_gazebo
     public gz::sim::ISystemConfigure,
     public gz::sim::ISystemPreUpdate,
     public gz::sim::ISystemUpdate,
-    public gz::sim::ISystemPostUpdate,
+    public gz::sim::ISystemPostUpdate
   {
     // Plugins inheriting ISystemConfigure must implement the Configure 
     // callback. This is called when a system is initially loaded. 

--- a/ros_gz_example_gazebo/include/ros_gz_example_gazebo/FullSystem.hh
+++ b/ros_gz_example_gazebo/include/ros_gz_example_gazebo/FullSystem.hh
@@ -36,7 +36,6 @@ namespace ros_gz_example_gazebo
     public gz::sim::ISystemPreUpdate,
     public gz::sim::ISystemUpdate,
     public gz::sim::ISystemPostUpdate,
-    public gz::sim::ISystemReset
   {
     // Plugins inheriting ISystemConfigure must implement the Configure 
     // callback. This is called when a system is initially loaded. 
@@ -74,10 +73,6 @@ namespace ros_gz_example_gazebo
     public: void PostUpdate(const gz::sim::UpdateInfo &_info,
                 const gz::sim::EntityComponentManager &_ecm) override;
 
-    // Plugins inheriting ISystemReset must implement the Reset callback. 
-    // This is called when simulation is reset/rewound to initial conditions.
-    public: void Reset(const gz::sim::UpdateInfo &_info,
-                gz::sim::EntityComponentManager &_ecm) override;
   };
 }
 #endif

--- a/ros_gz_example_gazebo/package.xml
+++ b/ros_gz_example_gazebo/package.xml
@@ -9,6 +9,9 @@
   <author>Michael Carroll</author>
   <author>Dharini Dutia</author>
 
+  <depend>gz-sim6</depend>
+  <depend>gz-cmake2</depend>
+
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/ros_gz_example_gazebo/package.xml
+++ b/ros_gz_example_gazebo/package.xml
@@ -11,6 +11,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>ros_gz_example_description</depend>
+
   <test_depend>ament_lint_auto</test_depend>
 
   <export>

--- a/ros_gz_example_gazebo/package.xml
+++ b/ros_gz_example_gazebo/package.xml
@@ -9,9 +9,6 @@
   <author>Michael Carroll</author>
   <author>Dharini Dutia</author>
 
-  <depend>gz-sim6</depend>
-  <depend>gz-cmake2</depend>
-
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/ros_gz_example_gazebo/src/BasicSystem.cc
+++ b/ros_gz_example_gazebo/src/BasicSystem.cc
@@ -29,7 +29,7 @@
 
 // This is required to register the plugin. Make sure the interfaces match
 // what's in the header.
-GZ_ADD_PLUGIN(
+IGNITION_ADD_PLUGIN(
     ros_gz_example_gazebo::BasicSystem,
     gz::sim::System,
     ros_gz_example_gazebo::BasicSystem::ISystemPostUpdate)
@@ -42,8 +42,8 @@ void BasicSystem::PostUpdate(const gz::sim::UpdateInfo &_info,
 {
   if (!_info.paused && _info.iterations % 1000 == 0)
   {
-    gzdbg << "ros_gz_example_gazebo::BasicSystem::PostUpdate" << std::endl;
+    igndbg << "ros_gz_example_gazebo::BasicSystem::PostUpdate" << std::endl;
   }
 }
 
-}  // namespace ros_gz_example_gazeba
+}  // namespace ros_gz_example_gazebo

--- a/ros_gz_example_gazebo/src/FullSystem.cc
+++ b/ros_gz_example_gazebo/src/FullSystem.cc
@@ -36,7 +36,6 @@ GZ_ADD_PLUGIN(
     ros_gz_example_gazebo::FullSystem::ISystemPreUpdate,
     ros_gz_example_gazebo::FullSystem::ISystemUpdate,
     ros_gz_example_gazebo::FullSystem::ISystemPostUpdate,
-    ros_gz_example_gazebo::FullSystem::ISystemReset
 )
 
 namespace ros_gz_example_gazebo 
@@ -77,9 +76,4 @@ void FullSystem::PostUpdate(const gz::sim::UpdateInfo &_info,
   }
 }
 
-void FullSystem::Reset(const gz::sim::UpdateInfo &_info,
-                       gz::sim::EntityComponentManager &_ecm)
-{
-  gzdbg << "ros_gz_example_gazebo::FullSystem::Reset" << std::endl;
-}
 }  // namespace ros_gz_example_gazeba

--- a/ros_gz_example_gazebo/src/FullSystem.cc
+++ b/ros_gz_example_gazebo/src/FullSystem.cc
@@ -29,13 +29,13 @@
 
 // This is required to register the plugin. Make sure the interfaces match
 // what's in the header.
-GZ_ADD_PLUGIN(
+IGNITION_ADD_PLUGIN(
     ros_gz_example_gazebo::FullSystem,
     gz::sim::System,
     ros_gz_example_gazebo::FullSystem::ISystemConfigure,
     ros_gz_example_gazebo::FullSystem::ISystemPreUpdate,
     ros_gz_example_gazebo::FullSystem::ISystemUpdate,
-    ros_gz_example_gazebo::FullSystem::ISystemPostUpdate,
+    ros_gz_example_gazebo::FullSystem::ISystemPostUpdate
 )
 
 namespace ros_gz_example_gazebo 
@@ -46,7 +46,7 @@ void FullSystem::Configure(const gz::sim::Entity &_entity,
                 gz::sim::EntityComponentManager &_ecm,
                 gz::sim::EventManager &_eventManager)
 {
-  gzdbg << "ros_gz_example_gazebo::FullSystem::Configure on entity: " << _entity << std::endl;
+  igndbg << "ros_gz_example_gazebo::FullSystem::Configure on entity: " << _entity << std::endl;
 }
 
 void FullSystem::PreUpdate(const gz::sim::UpdateInfo &_info,
@@ -54,7 +54,7 @@ void FullSystem::PreUpdate(const gz::sim::UpdateInfo &_info,
 {
   if (!_info.paused && _info.iterations % 1000 == 0)
   {
-    gzdbg << "ros_gz_example_gazebo::FullSystem::PreUpdate" << std::endl;
+    igndbg << "ros_gz_example_gazebo::FullSystem::PreUpdate" << std::endl;
   }
 }
 
@@ -63,7 +63,7 @@ void FullSystem::Update(const gz::sim::UpdateInfo &_info,
 {
   if (!_info.paused && _info.iterations % 1000 == 0)
   {
-    gzdbg << "ros_gz_example_gazebo::FullSystem::Update" << std::endl;
+    igndbg << "ros_gz_example_gazebo::FullSystem::Update" << std::endl;
   }
 }
 
@@ -72,8 +72,8 @@ void FullSystem::PostUpdate(const gz::sim::UpdateInfo &_info,
 {
   if (!_info.paused && _info.iterations % 1000 == 0)
   {
-    gzdbg << "ros_gz_example_gazebo::FullSystem::PostUpdate" << std::endl;
+    igndbg << "ros_gz_example_gazebo::FullSystem::PostUpdate" << std::endl;
   }
 }
 
-}  // namespace ros_gz_example_gazeba
+}  // namespace ros_gz_example_gazebo

--- a/ros_gz_example_gazebo/worlds/diff_drive.sdf
+++ b/ros_gz_example_gazebo/worlds/diff_drive.sdf
@@ -10,21 +10,21 @@
 <sdf version="1.8">
   <world name="demo">
     <plugin
-      filename="gz-sim-physics-system"
-      name="gz::sim::systems::Physics">
+      filename="ignition-gazebo-physics-system"
+      name="ignition::gazebo::systems::Physics">
     </plugin>
     <plugin
-      filename="gz-sim-sensors-system"
-      name="gz::sim::systems::Sensors">
+      filename="ignition-gazebo-sensors-system"
+      name="ignition::gazebo::systems::Sensors">
       <render_engine>ogre2</render_engine>
     </plugin>
     <plugin
-      filename="gz-sim-scene-broadcaster-system"
-      name="gz::sim::systems::SceneBroadcaster">
+      filename="ignition-gazebo-scene-broadcaster-system"
+      name="ignition::gazebo::systems::SceneBroadcaster">
     </plugin>
     <plugin
-      filename="gz-sim-user-commands-system"
-      name="gz::sim::systems::UserCommands">
+      filename="ignition-gazebo-user-commands-system"
+      name="ignition::gazebo::systems::UserCommands">
     </plugin>
     <plugin
       filename="BasicSystem"
@@ -84,13 +84,13 @@
       </include>
 
       <plugin
-        filename="gz-sim-joint-state-publisher-system"
-        name="gz::sim::systems::JointStatePublisher">
+        filename="ignition-gazebo-joint-state-publisher-system"
+        name="ignition::gazebo::systems::JointStatePublisher">
       </plugin>
 
       <plugin
-        filename="gz-sim-pose-publisher-system"
-        name="gz::sim::systems::PosePublisher">
+        filename="ignition-gazebo-pose-publisher-system"
+        name="ignition::gazebo::systems::PosePublisher">
         <publish_link_pose>true</publish_link_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
@@ -98,8 +98,8 @@
       </plugin>
 
       <plugin
-        filename="gz-sim-odometry-publisher-system"
-        name="gz::sim::systems::OdometryPublisher">
+        filename="ignition-gazebo-odometry-publisher-system"
+        name="ignition::gazebo::systems::OdometryPublisher">
         <odom_frame>diff_drive/odom</odom_frame>
         <robot_base_frame>diff_drive</robot_base_frame>
       </plugin>

--- a/template_workspace.yaml
+++ b/template_workspace.yaml
@@ -4,12 +4,3 @@ repositories:
     type: git
     url: https://github.com/gazebosim/ros_gz_project_template.git
     version: main
-  # Must compile ros_gz from source because Humble + Garden is not an official combination
-  ros_gz:
-    type: git
-    url: https://github.com/gazebosim/ros_gz.git
-    version: humble
-  sdformat_urdf:
-    type: git
-    url: https://github.com/ros/sdformat_urdf.git
-    version: ros2


### PR DESCRIPTION
ros_gz_project_template migration:

1. CMake changes, Removed Reset from FullSystem.hh and FullSystem.cc,
2. Update build instructions 
3. namespace updates, using `gz`  wherever possible

Note: now we have a fortress branch as some migration artefacts needed `ign-` but main branch should have general compatibility Harmonic onwards.
