### PR TITLE
Removing double entry for clock in bridge config

### DIFF
--- a/ros_gz_example_bringup/config/ros_gz_example_bridge.yaml
+++ b/ros_gz_example_bringup/config/ros_gz_example_bridge.yaml
@@ -19,11 +19,6 @@
   ros_type_name: "sensor_msgs/msg/LaserScan"
   gz_type_name: "gz.msgs.LaserScan"
   direction: GZ_TO_ROS
-- ros_topic_name: "/clock"
-  gz_topic_name: "/clock"
-  ros_type_name: "rosgraph_msgs/msg/clock"
-  gz_type_name: "gz.msgs.Clock"
-  direction: GZ_TO_ROS
 - ros_topic_name: "/joint_states"
   gz_topic_name: "/world/demo/model/diff_drive/joint_state"
   ros_type_name: "sensor_msgs/msg/JointState"


### PR DESCRIPTION

# 🦟 Bug fix

Fixes #17 

## Summary
Running the template and start the "ros2 launch ros_gz_example_bringup diff_drive.launch.py" command will isssue a warning 
[parameter_bridge-2] [WARN] [1710065920.771585053] [ros_gz_bridge]: Failed to create a bridge for topic [/clock] with ROS2 type [rosgraph_msgs/msg/clock] to topic [/clock] with Gazebo Transport type [gz.msgs.Clock] which will disappear, when double entry is removed

## Checklist
- [X] Signed all commits for DCO
- [] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [X] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
