### PR TITLE
Fixing the frame id for the Lidar for harmonic

### DIFF
--- a/ros_gz_example_bringup/config/ros_gz_example_bridge.yaml
+++ b/ros_gz_example_bringup/config/ros_gz_example_bridge.yaml
@@ -19,11 +19,6 @@
   ros_type_name: "sensor_msgs/msg/LaserScan"
   gz_type_name: "gz.msgs.LaserScan"
   direction: GZ_TO_ROS
-- ros_topic_name: "/clock"
-  gz_topic_name: "/clock"
-  ros_type_name: "rosgraph_msgs/msg/clock"
-  gz_type_name: "gz.msgs.Clock"
-  direction: GZ_TO_ROS
 - ros_topic_name: "/joint_states"
   gz_topic_name: "/world/demo/model/diff_drive/joint_state"
   ros_type_name: "sensor_msgs/msg/JointState"

--- a/ros_gz_example_description/models/diff_drive/model.sdf
+++ b/ros_gz_example_description/models/diff_drive/model.sdf
@@ -164,7 +164,12 @@
         <sensor name='gpu_lidar' type='gpu_lidar'>
           <pose>0 0 0 0 0 0</pose>
           <topic>scan</topic>
+          <!-- 
+             gzwarn << "The `ignition_frame_id` tag is deprecated. "
+               << "Please use `gz_frame_id` instead." << std::endl;
           <ignition_frame_id>diff_drive/lidar_link</ignition_frame_id>
+          -->
+          <gz_frame_id>diff_drive/lidar_link</gz_frame_id>
           <update_rate>10</update_rate>
           <lidar>
             <scan>


### PR DESCRIPTION

# 🦟 Bug fix

Fixes #23 

## Summary

Just replace the XML tag in the model.sdf file to be compliant with the renaming of ignition to gazebo 
          <!-- 
             gzwarn << "The `ignition_frame_id` tag is deprecated. "
               << "Please use `gz_frame_id` instead." << std::endl;
          <ignition_frame_id>diff_drive/lidar_link</ignition_frame_id>
          -->
          <gz_frame_id>diff_drive/lidar_link</gz_frame_id>
          <update_rate>10</update_rate>

## Checklist
- [X ] Signed all commits for DCO
- [- ] Updated documentation (as needed)
- [- ] Updated migration guide (as needed)
- [X ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [- ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))

Signed-off-by: cord.burmeister@live.de
