### PR TITLE
Fix branch for sdformat_urdf

### DIFF
--- a/template_workspace.yaml
+++ b/template_workspace.yaml
@@ -12,4 +12,4 @@ repositories:
   sdformat_urdf:
     type: git
     url: https://github.com/ros/sdformat_urdf.git
-    version: ros2
+    version: rolling


### PR DESCRIPTION
`sdformat_urdf` repository changed the branch names. Use `rolling` instead of the old `ros2` in the vcs file.