### PR TITLE
[not important] fixing a spelling error in a comment of a cmake file  

### DIFF
--- a/ros_gz_example_gazebo/CMakeLists.txt
+++ b/ros_gz_example_gazebo/CMakeLists.txt
@@ -96,7 +96,7 @@ endif()
 
 
 # Following hooks are used to ensure that the correct environment variables
-# will be set by exectuting 'sourece install/setup.bash' after compilation.
+# will be set by exectuting 'source install/setup.bash' after compilation.
 # When using this template for your project, change the filenames of the
 # files in the 'hooks' folder, to correspond to your project name.
 ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/hooks/${PROJECT_NAME}.dsv.in")


### PR DESCRIPTION


# 🦟 spelling fix
Fixes 39

## Summary
Changing a spelling error in the comment that was bothering me  when i was using the cmake file as an example for my own packages.
 I raised it in an issue  [here](https://github.com/gazebosim/ros_gz_project_template/issues/39 ) then realized i had the free will to fix it.
## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
