### PR TITLE
Remove versions and used vendored gz packages

### DIFF
--- a/ros_gz_example_gazebo/CMakeLists.txt
+++ b/ros_gz_example_gazebo/CMakeLists.txt
@@ -10,23 +10,13 @@ project(ros_gz_example_gazebo)
 find_package(ament_cmake REQUIRED)
 find_package(ros_gz_example_description REQUIRED)
 
-find_package(gz-cmake3 REQUIRED)
-find_package(gz-plugin2 REQUIRED COMPONENTS register)
-set(GZ_PLUGIN_VER ${gz-plugin2_VERSION_MAJOR})
-find_package(gz-common5 REQUIRED COMPONENTS profiler)
-set(GZ_COMMON_VER ${gz-common5_VERSION_MAJOR})
-
-# Harmonic
-if("$ENV{GZ_VERSION}" STREQUAL "harmonic")
-  find_package(gz-sim8 REQUIRED)
-  set(GZ_SIM_VER ${gz-sim8_VERSION_MAJOR})
-  message(STATUS "Compiling against Gazebo Harmonic")
-# Default to Garden
-else()
-  find_package(gz-sim7 REQUIRED)
-  set(GZ_SIM_VER ${gz-sim7_VERSION_MAJOR})
-  message(STATUS "Compiling against Gazebo Garden")
-endif()
+find_package(gz_plugin_vendor REQUIRED)
+find_package(gz-plugin REQUIRED COMPONENTS register)
+find_package(gz_common_vendor REQUIRED)
+find_package(gz-common REQUIRED COMPONENTS profiler)
+find_package(gz_sim_vendor REQUIRED)
+find_package(gz-sim REQUIRED)
+  
 
 
 # Following 'add_library' directive defines a library target named 'BasicSystem'.
@@ -52,7 +42,7 @@ target_include_directories(
 # be linked to anoter target. 
 # ${GZ_SIM_VER} is substituted by the value that is was set to above.
 target_link_libraries(BasicSystem PRIVATE
-  gz-sim${GZ_SIM_VER}::gz-sim${GZ_SIM_VER})
+  gz-sim::gz-sim)
 
 
 # Following directives similarly specify another target: 'FullSystem'.
@@ -66,7 +56,7 @@ target_include_directories(
 )
 
 target_link_libraries(FullSystem PRIVATE
-  gz-sim${GZ_SIM_VER}::gz-sim${GZ_SIM_VER})
+  gz-sim::gz-sim)
 
 
 

--- a/ros_gz_example_gazebo/package.xml
+++ b/ros_gz_example_gazebo/package.xml
@@ -11,7 +11,10 @@
 
   <depend>ros_gz_example_description</depend>
   <depend>gz_sim_vendor</depend>
-
+  <depend>gz_cmake_vendor</depend>
+  <depend>gz_plugin_vendor</depend>
+  <depend>gz_common_vendor</depend>
+ 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/ros_gz_example_gazebo/package.xml
+++ b/ros_gz_example_gazebo/package.xml
@@ -10,6 +10,7 @@
   <author>Dharini Dutia</author>
 
   <depend>ros_gz_example_description</depend>
+  <depend>gz_sim_vendor</depend>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 


### PR DESCRIPTION

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸

# 🎉 New feature

Closes #[37](https://github.com/gazebosim/ros_gz_project_template/issues/37)

## Summary
As gazebo moves to version-free targets this repository also needs an update. This will provide users with a good starting point to build on future versio of these templates.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
